### PR TITLE
Implement `ignores` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Initializes the ESLint config.
 | Property       | Type                                     | Description                                         | Link                                                                               |
 | :------------- | :--------------------------------------- | :-------------------------------------------------- | :--------------------------------------------------------------------------------- |
 | **library**    | `boolean`                                | Whether to use the recommended rules for libraries. |                                                                                    |
+| **ignores?**   | `boolean \| IgnoresConfigOption`         | Additional ignores configuration.                   |                                                                                    |
 | **base?**      | `Partial<Linter.RulesRecord>`            | Overrides for the default base rules.               | [eslint](https://eslint.org/docs/latest/rules/)                                    |
 | **typescript** | `boolean \| Partial<Linter.RulesRecord>` | Overrides for the default TypeScript rules          | [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint)        |
 | **jsdoc**      | `boolean \| Partial<Linter.RulesRecord>` | Overrides for the default JSDoc rules.              | [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc)                |
@@ -60,6 +61,15 @@ Initializes the ESLint config.
 | **sort**       | `boolean \| Partial<Linter.RulesRecord>` | Overrides for the default sort rules.               | [eslint-plugin-sort](https://github.com/eslint-community/eslint-plugin-promise)    |
 | **stylistic**  | `boolean \| Partial<Linter.RulesRecord>` | Overrides for the default stylistic rules.          | [eslint-stylistic](https://github.com/eslint-stylistic/eslint-stylistic)           |
 | **prettier**   | `boolean \| Partial<Linter.RulesRecord>` | Overrides for the default prettier rules.           | [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)       |
+
+### `interface IgnoresConfigOption`
+
+The configuration settings for `ignores`.
+
+| Parameter      | Type                                           | Description                                                                                                                    |
+| :------------- | :--------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| **globs**      | `string[]`                                     | The customizable options.                                                                                                      |
+| **gitignore?** | `boolean \| { cwd: string }` (_default: true_) | Whether to ignore all globs listed in the project's `.gitignore`. Optionally, pass in an object to specify additional options. |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
+        "@eslint/compat": "^1.2.5",
         "@eslint/js": "^9.18.0",
         "@stylistic/eslint-plugin": "^2.13.0",
         "@typescript-eslint/parser": "^8.20.0",
@@ -371,6 +372,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.5.tgz",
+      "integrity": "sha512-5iuG/StT+7OfvhoBHPlmxkPA9om6aDUFgmD4+mWKAGsYt4vCe8rypneG03AuseyRHBmcCLXQtIH5S26tIoggLg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.10.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-sort": "^4.0.0",
+        "find-up-simple": "^1.0.0",
         "typescript-eslint": "^8.20.0"
       },
       "devDependencies": {
@@ -4539,6 +4540,18 @@
         "path-exists": "^5.0.0",
         "unicorn-magic": "^0.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-sort": "^4.0.0",
+    "find-up-simple": "^1.0.0",
     "typescript-eslint": "^8.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
+    "@eslint/compat": "^1.2.5",
     "@eslint/js": "^9.18.0",
     "@stylistic/eslint-plugin": "^2.13.0",
     "@typescript-eslint/parser": "^8.20.0",

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -734,17 +734,7 @@ function tsConfig(options: ConfigOptions): Linter.Config[] {
 }
 
 export default function baseConfig(options: ConfigOptions): Linter.Config[] {
-  const config: Linter.Config[] = [
-    {
-      ignores: [
-        '**/node_modules/**/*',
-        '**/dist/**/*',
-        '**/build/**/*',
-        '**/coverage/**/*',
-      ],
-    },
-    ...jsConfig(options),
-  ];
+  const config: Linter.Config[] = jsConfig(options);
 
   if (options.typescript) {
     config.push(...tsConfig(options));

--- a/src/configs/ignores.ts
+++ b/src/configs/ignores.ts
@@ -1,0 +1,50 @@
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { includeIgnoreFile } from '@eslint/compat';
+import { type Linter } from 'eslint';
+import { findUpSync } from 'find-up-simple';
+
+import { type ConfigOptions } from '../index';
+
+const defaultIgnores = [
+  '**/node_modules',
+  '**/dist',
+  '**/output',
+  '**/coverage',
+  '**/.out',
+  '**/.output',
+  '**/.cache',
+  '**/tmp',
+  '**/.tmp',
+  '**/.vite',
+];
+
+export interface IgnoresConfigOption {
+  globs: string[];
+  gitignore?: boolean | { cwd: string };
+}
+
+export default function ignoresConfig(
+  options: ConfigOptions
+): Linter.FlatConfig[] {
+  const config: Linter.FlatConfig[] = [];
+
+  const { globs = [], gitignore = true } = options.ignores ?? {};
+
+  if (gitignore) {
+    const cwd = gitignore === true ? process.cwd() : gitignore.cwd;
+    const gitignorePath = findUpSync('.gitignore', { cwd });
+    if (!gitignorePath) {
+      throw new Error('No .gitignore found.');
+    }
+    config.push(
+      includeIgnoreFile(fileURLToPath(pathToFileURL(gitignorePath).href))
+    );
+  }
+
+  config.push({
+    ignores: [...defaultIgnores, ...globs],
+  });
+
+  return config;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { type Linter } from 'eslint';
 
 import baseConfig from './configs/base';
+import ignoresConfig, { type IgnoresConfigOption } from './configs/ignores';
 import importConfig from './configs/import';
 import jsdocConfig from './configs/jsdoc';
 import prettierConfig from './configs/prettier';
@@ -10,6 +11,7 @@ import stylisticConfig from './configs/stylistic';
 
 export interface ConfigOptions {
   library: boolean;
+  ignores?: IgnoresConfigOption;
   base?: Partial<Linter.RulesRecord>;
   typescript: boolean | Partial<Linter.RulesRecord>;
   jsdoc: boolean | Partial<Linter.RulesRecord>;
@@ -31,7 +33,10 @@ export default function createConfig(
   options: ConfigOptions,
   ...customConfigs: Linter.Config[]
 ): Linter.Config[] {
-  const configs: Linter.Config[] = baseConfig(options);
+  const configs: Linter.Config[] = [
+    ...ignoresConfig(options),
+    ...baseConfig(options),
+  ];
 
   if (options.jsdoc) {
     configs.push(...jsdocConfig(options));


### PR DESCRIPTION
This adds the ability to configure the `ignores`.

The project's `.gitignore` file can now be included in the ignores and is enabled by default.